### PR TITLE
add higher capacity updation

### DIFF
--- a/ruvnl_consumer_app/app.py
+++ b/ruvnl_consumer_app/app.py
@@ -177,7 +177,7 @@ def save_generation_data(
         # check if generation exceeds capacity and update if necessary
         if write_to_db:
             site_uuid = asset_data["site_uuid"].iloc[0]
-            max_power = asset_data["power_kw"].max()
+            max_power = float(asset_data["power_kw"].max())  
             
             site = db_session.query(SiteSQL).filter(SiteSQL.site_uuid == site_uuid).first()
             if site and max_power > site.capacity_kw:

--- a/ruvnl_consumer_app/app.py
+++ b/ruvnl_consumer_app/app.py
@@ -182,10 +182,11 @@ def save_generation_data(
             site = db_session.query(SiteSQL).filter(SiteSQL.site_uuid == site_uuid).first()
             if site and max_power > site.capacity_kw:
                 log.info(
-                    f"Updating capacity for site {site_uuid} from {site.capacity_kw}kW to {max_power}kW"
+                    f"Updating capacity for site {site_uuid} from {site.capacity_kw}kW "
+                    f"to {max_power}kW"
                 )
                 site.capacity_kw = max_power
-                db_session.add(site)
+                db_session.commit()
 
         # Drop asset_type column
         asset_data = asset_data.drop("asset_type", axis=1)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -190,7 +190,6 @@ def test_save_generation_data(write_to_db, db_session, caplog, associated_genera
     
     # generation data to exceed capacity
     associated_generation_data.loc[0, "power_kw"] = initial_capacity * 2
-    
     save_generation_data(db_session, associated_generation_data, write_to_db)
 
     if write_to_db:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -179,15 +179,30 @@ class TestMergeGenerationDataWithSite:
 
 @pytest.mark.parametrize("write_to_db", [True, False])
 def test_save_generation_data(write_to_db, db_session, caplog, associated_generation_data):
-    """Test for saving generation data"""
+    """Test for saving generation data and capacity updates"""
 
     caplog.set_level(logging.INFO)
+    
+    # initial site capacity
+    site_uuid = associated_generation_data["site_uuid"].iloc[0]
+    site = db_session.query(SiteSQL).filter(SiteSQL.site_uuid == site_uuid).first()
+    initial_capacity = site.capacity_kw
+    
+    # generation data to exceed capacity
+    associated_generation_data.loc[0, "power_kw"] = initial_capacity * 2
+    
     save_generation_data(db_session, associated_generation_data, write_to_db)
 
     if write_to_db:
         assert db_session.query(GenerationSQL).count() == 2
+        # Check capacity was updated
+        site = db_session.query(SiteSQL).filter(SiteSQL.site_uuid == site_uuid).first()
+        assert site.capacity_kw == initial_capacity * 2
     else:
         assert "Generation data:" in caplog.text
+        # Verify capacity wasn't updated when not writing to db
+        site = db_session.query(SiteSQL).filter(SiteSQL.site_uuid == site_uuid).first()
+        assert site.capacity_kw == initial_capacity
 
 
 @freeze_time("2021-01-31T10:01:00Z")
@@ -212,3 +227,4 @@ def test_app(write_to_db, requests_mock, db_session, caplog):
         assert db_session.query(GenerationSQL).count() == init_n_generation_data + 2
     else:
         assert db_session.query(GenerationSQL).count() == init_n_generation_data
+


### PR DESCRIPTION
# Description

Added functionality to automatically update site capacity when observed generation exceeds current capacity. This implements a rolling maximum approach to site capacity, ensuring our capacity values always reflect the highest observed generation.

Key changes:
- Modified `save_generation_data` to check if generation exceeds site capacity
- Added automatic capacity updates when generation exceeds current capacity
- Added logging for capacity updates
- Only updates capacity when write_to_db is True

Fixes #26 

## How Has This Been Tested?

- Enhanced existing `test_save_generation_data` to verify capacity updates:
  - Tests both write_to_db=True and False scenarios
  - Verifies capacity is updated when generation exceeds it
  - Confirms capacity remains unchanged when write_to_db=False
  - Maintains all existing generation data saving tests

- [x] Yes

No data plotting required as this is a simple numerical comparison and update.

- [x] N/A

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (added docstring updates)
- [x] I have added tests that prove my fix is effective
- [x] I have checked my code and corrected any misspellings
