### PR TITLE
fix: add missing region parameter to seeded sites

### DIFF
--- a/scripts/seed_local_db.py
+++ b/scripts/seed_local_db.py
@@ -53,6 +53,7 @@ def seed_db():
             capacity_kw=4,
             asset_type="pv",
             country="india",
+            region="ruvnl",
         )
 
         site, _ = create_site(
@@ -64,6 +65,7 @@ def seed_db():
             capacity_kw=4,
             asset_type="wind",
             country="india",
+            region="ruvnl",
         )
 
         print("Database successfully seeded")


### PR DESCRIPTION
# Fix: Add missing region parameter to database seeder

## Problem
The `poetry run seeder` command creates sites without the `region` parameter, but the main app filters sites by `region="ruvnl"`. This causes the app to fail with "No sites found for ruvnl region" after seeding.

## Solution
Added `region="ruvnl"` parameter to both PV and wind site creation calls in `scripts/seed_local_db.py`.

## Changes
- Added `region="ruvnl"` to PV site creation
- Added `region="ruvnl"` to wind site creation

**Type**: Bug fix
**Breaking**: No